### PR TITLE
Access-Control-Expose-Headers should be in regular responses, instead of preflight response

### DIFF
--- a/lib/manifold.rb
+++ b/lib/manifold.rb
@@ -33,6 +33,8 @@ module Manifold
 
         headers['Access-Control-Allow-Origin'] = "*"
 
+        headers['Access-Control-Expose-Headers'] = Manifold.config.expose.join(', ') if Manifold.config.expose
+
         [status, headers, body]
       end
     end
@@ -49,10 +51,6 @@ module Manifold
         Manifold.config.accept,
         'Authorization'
       ].compact.join(', ')
-
-      if Manifold.config.expose
-        headers['Access-Control-Expose-Headers'] = Manifold.config.expose.join(', ')
-      end
 
       headers['Access-Control-Allow-Credentials'] = "true"
 

--- a/manifold.gemspec
+++ b/manifold.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |gem|
   gem.version       = Manifold::VERSION
 
   gem.add_development_dependency "rack-test"
-  gem.add_development_dependency "rails"
+  gem.add_development_dependency "rails", '>= 3.0.0'
   gem.add_development_dependency "simplecov"
 end

--- a/test/mainfold_test.rb
+++ b/test/mainfold_test.rb
@@ -70,16 +70,6 @@ class ManifoldTest < MiniTest::Unit::TestCase
     assert_equal 'text/plain', last_response.content_type
   end
 
-  def test_allows_for_custom_headers_exposed
-    Manifold.config.expose = ["X-Request-ID"]
-
-    preflight "PATCH"
-
-    assert last_response.ok?
-    headers = last_response.headers
-    assert_equal "X-Request-ID", headers['Access-Control-Expose-Headers']
-  end
-
   def tests_allow_for_custom_headers_accept
     Manifold.config.accept = ["X-Rate-Limit"]
 
@@ -96,6 +86,16 @@ class ManifoldTest < MiniTest::Unit::TestCase
     assert last_response.ok?
     headers = last_response.header
     assert headers['Access-Control-Max-Age']
+  end
+
+  def test_allows_for_custom_headers_exposed
+    Manifold.config.expose = ["X-Request-ID"]
+
+    get "/"
+
+    assert last_response.ok?
+    headers = last_response.headers
+    assert_equal "X-Request-ID", headers['Access-Control-Expose-Headers']
   end
 
   def test_adds_cors_support_for_simple_requests


### PR DESCRIPTION
Access-Control-Expose-Headers should be in regular responses, instead of preflight response, as per http://www.html5rocks.com/en/tutorials/cors/ and http://www.w3.org/TR/cors/#access-control-expose-headers-response-header
